### PR TITLE
Added apple silicon troubleshoot steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,21 @@ Coming soon
 # Release notes
 
 [Here](RELEASENOTES.md)
+
+# Known Issues and Workarounds
+
+## Permission Issue on Apple Silicon
+Running Ring! on Apple Silicone with .NET 6 (x64) installed can result in permission errors such as this one:
+
+```
+[‘/etc/dotnet/install_location_x64’] failed to open: Permission denied.
+```
+
+Use the following workaround to resolve this issue: 
+* Navigate to `/etc` in Finder
+* Right click on the `dotnet` directory then select `Get Info` in the context menu
+* In the information panel, select the `+` sign and add your user to the permission pool
+* Update your privileges to `Read & Write` in the permissions table
+* Click on the `...` icon to `Apply to enclose items`. 
+
+This will grant you execution permissions for all the files and should resolve the error.


### PR DESCRIPTION
Added notes on steps to troubleshoot permission issue when running ring on Mac Silicon (.NET 6 x64 — Intel Version through Rosetta).