### PR TITLE
tests: add urls override test for aspnetcore

### DIFF
--- a/src/ATech.Ring.DotNet.Cli/Program.cs
+++ b/src/ATech.Ring.DotNet.Cli/Program.cs
@@ -126,18 +126,17 @@ try
         container.Register<Func<LightInject.Scope>>(x => x.BeginScope);
     });
 
-    builder.Host.ConfigureAppConfiguration((c, b) =>
+    builder.Host.ConfigureAppConfiguration((_, b) =>
     {
-        b.AddJsonFile(InstallationDir.AppsettingsJsonPath(), optional: false)
-         .AddInMemoryCollection(new Dictionary<string, string> { ["ring:port"] = options.Port.ToString() })
-         .AddUserSettingsFile()
-         .AddEnvironmentVariables();
-
+        b.AddJsonFile(InstallationDir.AppsettingsJsonPath(), optional: false);
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             b.AddJsonFile(InstallationDir.AppsettingsJsonPath("Windows"), optional: false);
         }
+        b.AddUserSettingsFile();
         b.AddJsonFile(Path.Combine(originalWorkingDir, ".ring", "appsettings.json"), optional: true);
+        b.AddInMemoryCollection(new Dictionary<string, string> { ["ring:port"] = options.Port.ToString() });
+        b.AddEnvironmentVariables();
     });
     builder.Host.UseServiceProviderFactory(new LightInjectServiceProviderFactory());
     builder.WebHost.UseLightInject(container);

--- a/src/ATech.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
+++ b/src/ATech.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
@@ -30,7 +30,7 @@ public class DotnetCliBundle : ITool
         if (File.Exists(ctx.ExePath))
         {
             _exeRunner.ExePath = ctx.ExePath;
-            return await _exeRunner.RunProcessAsync(ctx.WorkingDir, null, null, token);
+            return await _exeRunner.RunProcessAsync(ctx.WorkingDir, DefaultEnvVars, null, token);
         }
         if (File.Exists(ctx.EntryAssemblyPath))
         {

--- a/tests/Ring.Tests.Integration/Ring.Tests.Integration.fsproj
+++ b/tests/Ring.Tests.Integration/Ring.Tests.Integration.fsproj
@@ -13,15 +13,16 @@
     <Compile Include="TestContext.fs" />
     <Compile Include="Shared.fs" />
     <Compile Include="Tests.Smoke.fs" />
+    <Compile Include="Tests.AspNetCore.fs" />
     <Compile Include="Tests.WorkspaceConfig.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Expecto" Version="9.*" />
-    <PackageReference Include="Fake.Core.Environment" Version="5.20.4" />
-    <PackageReference Include="Fake.Core.Process" Version="5.20.4" />
-    <PackageReference Include="FSharp.Control.Reactive" Version="5.0.2" />
+    <PackageReference Include="Fake.Core.Environment" Version="5.*" />
+    <PackageReference Include="Fake.Core.Process" Version="5.*" />
+    <PackageReference Include="FsHttp" Version="9.1.2" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Update="FSharp.Core" Version="6.*" />

--- a/tests/Ring.Tests.Integration/Shared.fs
+++ b/tests/Ring.Tests.Integration/Shared.fs
@@ -45,13 +45,6 @@ let logToFile fileName (options: Options) =
 let globalOptions (dir:TestDir) = { localOptions dir with LocalTool = None}
 
 
-type Ring with
-
-  member x.expect (typ:M) =
-    let timeout = TimeSpan.FromSeconds(60)
-    x.Client.WaitUntilMessage(typ, timeout = timeout), typ
-    
-  
 module Expect =
   let forId (id: string) (events: (Msg option * M) seq) =
     
@@ -59,3 +52,13 @@ module Expect =
       let event, typ = event
       let runnable = $"Should receive a message of type {typ}" |> Expect.wantSome event
       "Runnable Id should be correct" |> Expect.equal runnable.Payload id
+
+type Ring with
+
+  member x.expect (typ:M) =
+    let timeout = TimeSpan.FromSeconds(60)
+    x.Client.WaitUntilMessage(typ, timeout = timeout), typ
+  
+  member x.waitUntilHealthy (id: string) =
+    [ x.expect M.RUNNABLE_HEALTHY ]
+    |> Expect.forId id

--- a/tests/Ring.Tests.Integration/Tests.AspNetCore.fs
+++ b/tests/Ring.Tests.Integration/Tests.AspNetCore.fs
@@ -1,0 +1,41 @@
+module Ring.Tests.Integration.AspNetCore
+
+open Expecto
+
+open FsHttp
+open FsHttp.Dsl
+open FsHttp.DslCE
+open Ring.Tests.Integration.RingControl
+open ATech.Ring.Protocol.v2
+open Ring.Tests.Integration.Shared
+open Ring.Tests.Integration.TestContext
+
+
+[<Tests>]
+let tests =
+  testList "AspNetCore runnable tests" [
+
+    testTask "should override url via Urls" {
+      use ctx = new TestContext(localOptions >> logToFile "aspnetcore-urls.ring.log")
+      let! (ring : Ring, dir: TestDir) = ctx.Init()
+
+      ring.Headless(debugMode=true)
+      do! ring.Client.Connect()
+      do! ring.Client.LoadWorkspace (dir.InSourceDir "../resources/aspnetcore-urls.toml")
+      do! ring.Client.StartWorkspace()
+      
+      ring.waitUntilHealthy "aspnetcore"
+      
+      let response =
+        http {
+          GET "http://localhost:7123"
+        }
+        |> Request.send
+        |> Response.assertOk
+        |> Response.toText
+      
+      "Response on port 7123 should be OK" |> Expect.equal response "OK"
+        
+      do! ring.Client.Terminate() 
+    }
+  ] |> testLabel "aspnetcore"

--- a/tests/Ring.Tests.Integration/Tests.Smoke.fs
+++ b/tests/Ring.Tests.Integration/Tests.Smoke.fs
@@ -61,8 +61,7 @@ let tests =
         M.RUNNABLE_DESTROYED
       ]
       |> Seq.map ring.expect
-      |> Expect.forId "k8s-debug-poc"
-      
+      |> Expect.forId "k8s-debug-poc"  
     }
 
     testTask "discover and run default workspace config if exists" {

--- a/tests/resources/apps/aspnetcore/Program.cs
+++ b/tests/resources/apps/aspnetcore/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.MapGet("/", () => "OK");
 
 app.Run();

--- a/tests/resources/apps/aspnetcore/Properties/launchSettings.json
+++ b/tests/resources/apps/aspnetcore/Properties/launchSettings.json
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7279;http://localhost:5078",
+      "applicationUrl": "http://localhost:5078",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/tests/resources/aspnetcore-urls.toml
+++ b/tests/resources/aspnetcore-urls.toml
@@ -1,0 +1,3 @@
+[[aspnetcore]]
+csproj = "apps/aspnetcore/aspnetcore.csproj"
+urls = ["http://+:7123"]


### PR DESCRIPTION
This PR fixes:
* ring: configuration sources priority (env vars were not correctly working for configuring ring on Windows do to ordering).
* aspnetcore: DefaultEnvVars not passed on windows when running from a binary (exe) causing Urls override not working. 